### PR TITLE
Fixed CharacterSkillsPanelSkillElement prop types discrepancy

### DIFF
--- a/app/scripts/character/character-builder.jsx
+++ b/app/scripts/character/character-builder.jsx
@@ -134,21 +134,32 @@ export default class CharacterBuilder extends React.Component {
 
 	/**
 	 * Inspect a node and reveal its details
-	 * @param {String} id The picked node id
+	 * @param {String|Object} node The picked node(s)
 	 */
-	inspectSkill(id) {
-		var nodeData = this.getNodeDataById(id),
-			splitID = id.split('-'),
+	inspectSkill(node) {
+		var nodeData, splitID, nodeObj;
+
+		if (typeof node === 'string') {
+			nodeData = this.getNodeDataById(node);
+			splitID = node.split('-'),
 			nodeObj = {
 				id: splitID[0],
 				type: nodeData.type,
 				upgrades: []
 			};
 
-		if (nodeData.type === 'skill' || nodeData.type === 'upgrade') {
-			if (splitID[1] !== undefined) {
-				nodeObj.upgrades.push(splitID[1]);
+			if (nodeData.type === 'skill' || nodeData.type === 'upgrade') {
+				if (splitID[1] !== undefined) {
+					nodeObj.upgrades.push(splitID[1]);
+				}
 			}
+		} else {
+			nodeData = this.getNodeDataById(node.id);
+			nodeObj = {
+				id: node.id,
+				type: nodeData.type,
+				upgrades: node.upgrades
+			};
 		}
 
 		this.setState({

--- a/app/scripts/character/character-skills-panel-skill-element.jsx
+++ b/app/scripts/character/character-skills-panel-skill-element.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 /**
- * A CharacterSkillsPanelSkillElement is a skill and its selected upgrades 
+ * A CharacterSkillsPanelSkillElement is a skill and its selected upgrades
  * displayed in a {@link CharacterSkillsPanel}.
  * @class
  */
 export default class CharacterSkillsPanelSkillElement extends React.Component {
-	
+
 	/**
 	 * @constructor
 	 * @param {Object} props Component props
@@ -35,7 +35,7 @@ export default class CharacterSkillsPanelSkillElement extends React.Component {
 				<ul>
 					{this.props.upgrades.map(function(upgrade) {
 						return (
-							<li><small>Upgrade #{upgrade.id}</small></li>
+							<li><small>Upgrade #{upgrade}</small></li>
 						);
 					})}
 				</ul>
@@ -71,7 +71,7 @@ CharacterSkillsPanelSkillElement.defaultProps = {
 CharacterSkillsPanelSkillElement.propTypes = {
 	id: React.PropTypes.string.isRequired,
 	upgrades: React.PropTypes.arrayOf(
-		React.PropTypes.string
+		React.PropTypes.string.isRequired
 	),
 	active: React.PropTypes.bool
 };

--- a/app/scripts/character/character-skills-panel.jsx
+++ b/app/scripts/character/character-skills-panel.jsx
@@ -53,9 +53,7 @@ export default class CharacterSkillsPanel extends React.Component {
 
 			// Add upgrade to parent skill if is an upgrade
 			if (splitID[1] !== undefined) {
-				skills[splitID[0]].upgrades.push({
-					id: splitID[1]
-				});
+				skills[splitID[0]].upgrades.push(splitID[1]);
 			}
 		}
 


### PR DESCRIPTION
- Skills now display correctly again upon clicking a skill element in the side panel
- Upgrades are now passed with the correct format down the component chain

fix #34